### PR TITLE
Fix typo in deploymentViews property

### DIFF
--- a/structurizr.yaml
+++ b/structurizr.yaml
@@ -553,7 +553,7 @@ components:
           description: The set of dynamic views.
           items:
             $ref: '#/components/schemas/DynamicView'
-        deploymentView:
+        deploymentViews:
           type: array
           description: The set of deployment views.
           items:


### PR DESCRIPTION
Looks like there is a typo in views schema. `deploymentViews` key is expected: https://github.com/structurizr/java/blob/fb58852a1b3e614c83696e1afc069460b25e5f3f/structurizr-core/src/com/structurizr/view/ViewSet.java#L509